### PR TITLE
Add test mode; add metric support; let user set comfort zone level

### DIFF
--- a/Projects/rain_notifier/rain_notifier.py
+++ b/Projects/rain_notifier/rain_notifier.py
@@ -49,7 +49,7 @@ import json
 from grovepi import *
 import time
 import sys
-import my_rain_notifier
+
 
 def clear_led(status):
     """ change clear sky LED status """
@@ -92,7 +92,7 @@ def led_blink(blinkdelay):
     no additional sleep() is required as it's incorporated in the blinking
     """
     count = 0.0
-    blinkrate = 0.2
+    blinkrate = 0.4
     while count < float(blinkdelay):
         digitalWrite(rainled,1)
         time.sleep(blinkrate)   

--- a/Projects/rain_notifier/rain_notifier.py
+++ b/Projects/rain_notifier/rain_notifier.py
@@ -8,7 +8,7 @@
 #
 # Enter your zip code (or Postal Code) on the following line
 # (leave the name 'zip' as is, even if you have a postal code. )
-zip = 'YOUR_ZIP_CODE'
+zipcode = 'YOUR_ZIP_CODE'
 
 # once you have gotten an API Key from Wunderground (see tutorial), pleave provide it here
 # Wunderground API Key
@@ -48,6 +48,8 @@ import urllib2
 import json
 from grovepi import *
 import time
+import sys
+import my_rain_notifier
 
 def clear_led(status):
     """ change clear sky LED status """
@@ -70,7 +72,7 @@ def assign_rain(status, blink):
         # Light the RAIN LED on the umbrella
         # check if it needs to be blinking
         if blink == True:
-            led_blink() # no sleep required here
+            led_blink(DELAY) # no sleep required here
         else:
             digitalWrite(rainled,1)
             time.sleep(DELAY)
@@ -82,16 +84,16 @@ def assign_rain(status, blink):
         clear_led(1)
         time.sleep(DELAY)
 
-def led_blink():
+def led_blink(blinkdelay):
     """ forces the rain LED to blink
 
     rain LED will blink at a rate of 0.2 secs on, and 0.2 secs off
-    it will blink for a duration set by DELAY
+    it will blink for a duration set by blinkdelay
     no additional sleep() is required as it's incorporated in the blinking
     """
     count = 0.0
     blinkrate = 0.2
-    while count < float(DELAY):
+    while count < float(blinkdelay):
         digitalWrite(rainled,1)
         time.sleep(blinkrate)   
         digitalWrite(rainled,0)
@@ -106,6 +108,18 @@ def led_blink():
 url='http://api.wunderground.com/api/'+api_key+'/geolookup/conditions/q/'+zip+'.json'
 
 pinMode(rainled,"OUTPUT")
+
+
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    try:
+        clear_led(1)
+        led_blink(5)
+        clear_led(0)
+    except KeyboardInterrupt:
+        digitalWrite(clearled,0)
+        digitalWrite(rainled,0)
+    quit()
+
 if clearled > -1:
     pinMode(clearled,"OUTPUT")
 

--- a/Projects/rain_notifier/rain_notifier.py
+++ b/Projects/rain_notifier/rain_notifier.py
@@ -50,7 +50,6 @@ from grovepi import *
 import time
 import sys
 
-
 def clear_led(status):
     """ change clear sky LED status """
     if clearled > -1:

--- a/Projects/rain_notifier/rain_notifier.py
+++ b/Projects/rain_notifier/rain_notifier.py
@@ -1,39 +1,55 @@
 # rain_notifier.py
 #
-# This is a project that uses the Grove LED attached to an umbrella to remind 
+# This is a project that uses the Grove LED attached to an umbrella to remind
 # people to take their umbrella if it's raining or going to rain that day.
 #
-# You will need to modify the first few lines to make this project work for you.
-# Fee free to modify the rest of the program to make it behave the way you want it to.
+# You will need to modify the first few lines for this project work for you.
+# Fee free to modify the rest of the program to make it
+# behave the way you want it to.
 #
 # Enter your zip code (or Postal Code) on the following line
 # (leave the name 'zip' as is, even if you have a postal code. )
 zipcode = 'YOUR_ZIP_CODE'
 
-# once you have gotten an API Key from Wunderground (see tutorial), pleave provide it here
+# once you have gotten an API Key from Wunderground (see tutorial),
+# pleave provide it here
 # Wunderground API Key
 api_key = 'YOUR_WUNDERGROUND_API_KEY'
 
 # if you wish to use two LEDs, provide the port number of the second LED
-# The second LED is the one that will show there's no rain in the weather prediction
-# With two LEDs, one will always be on. 
+# The second LED is the one that will indicate
+# if there's no rain in the weather prediction
+# With two LEDs, one will always be on.
 # if you do not want a second LED, set this to -1
 clearled = 8
-
-# in case of rain, do you want the LED to blink in order to catch your attention more?
-# set to True for blinking, set to False for a steady warning
-BLINK = True
 
 ############################################################################
 # no modifications are required after this
 # however the next few lines can be tweaked easily
 ############################################################################
 
-# this is the delay between each polling of Wunderground. It's set to poll once every 5 minutes
-# you may prefer a faster polling.
-# the Wunderground free account does set a limit 
+# in case of rain, do you want the LED to blink
+# to catch your attention more?
+# set to True for blinking, set to False for a steady warning
+BLINK = True
 
-DELAY = 5*60 # in seconds
+# this is the delay between each polling of Wunderground.
+# It's set to poll once every 5 minutes
+# you may prefer a faster polling.
+# the Wunderground free account does set a limit
+DELAY = 5*60  # in seconds
+
+# Do you prefer to work in metric or imperial?
+# set METRIC to 1 to use the metric system
+# set METRIC to 0 to use imperial system
+METRIC = 1
+
+# rain threshold: what's your safety zone?
+# before you need an umbrella
+# if METRIC is set to 1, this will be in millimeters
+# if METRIC is set to 0, this will be in inches
+RAIN_THRESHOLD = 1
+
 
 # Pin for the rain LED on the umbrella
 rainled = 7
@@ -49,11 +65,14 @@ import json
 from grovepi import *
 import time
 import sys
+from my_rain_notifier import *
+
 
 def clear_led(status):
     """ change clear sky LED status """
     if clearled > -1:
-        digitalWrite(clearled,status)
+        digitalWrite(clearled, status)
+
 
 def assign_rain(status, blink):
     """ controls the LEDs status
@@ -65,27 +84,28 @@ def assign_rain(status, blink):
             False if the rain led does not need blinking
     no return value
     """
-    if status == True: # there will be rain
-        clear_led(0) # Turn off the CLEAR LED on the umbrella
-        
+
+    if status is True:  # there will be rain
+        clear_led(0)    # Turn off the CLEAR LED on the umbrella
+
         # Light the RAIN LED on the umbrella
-        # check if it needs to be blinking
-        if blink == True:
-            led_blink(DELAY) # no sleep required here
+        # first check if it needs to be blinking
+        if blink is True:
+            led_blink(DELAY)  # no sleep required here
         else:
-            digitalWrite(rainled,1)
+            digitalWrite(rainled, 1)
             time.sleep(DELAY)
 
-    else: # no rain in forecast
+    else:  # no rain in forecast
         # turn off the RAIN LED on the umbrella
-        digitalWrite(rainled,0)
+        digitalWrite(rainled, 0)
         # Turn on the CLEAR LED on the umbrella
         clear_led(1)
         time.sleep(DELAY)
 
+
 def led_blink(blinkdelay):
     """ forces the rain LED to blink
-
     rain LED will blink at a rate of 0.2 secs on, and 0.2 secs off
     it will blink for a duration set by blinkdelay
     no additional sleep() is required as it's incorporated in the blinking
@@ -93,20 +113,20 @@ def led_blink(blinkdelay):
     count = 0.0
     blinkrate = 0.4
     while count < float(blinkdelay):
-        digitalWrite(rainled,1)
-        time.sleep(blinkrate)   
-        digitalWrite(rainled,0)
-        time.sleep(blinkrate)   
+        digitalWrite(rainled, 1)
+        time.sleep(blinkrate)
+        digitalWrite(rainled, 0)
+        time.sleep(blinkrate)
         count += (2*blinkrate)
 
 
 #########################################################################
 
-    
 # Zip code of location
-url='http://api.wunderground.com/api/'+api_key+'/geolookup/conditions/q/'+zip+'.json'
+url = 'http://api.wunderground.com/api/' + api_key
+url = url + '/geolookup/conditions/q/' + zipcode + '.json'
 
-pinMode(rainled,"OUTPUT")
+pinMode(rainled, "OUTPUT")
 
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
@@ -115,12 +135,12 @@ if len(sys.argv) > 1 and sys.argv[1] == 'test':
         led_blink(5)
         clear_led(0)
     except KeyboardInterrupt:
-        digitalWrite(clearled,0)
-        digitalWrite(rainled,0)
+        digitalWrite(clearled, 0)
+        digitalWrite(rainled, 0)
     quit()
 
 if clearled > -1:
-    pinMode(clearled,"OUTPUT")
+    pinMode(clearled, "OUTPUT")
 
 try:
     while True:
@@ -129,11 +149,13 @@ try:
         f.close()
         parsed_json = json.loads(json_string)
         location = parsed_json['location']['city']
-        precip_today_in = parsed_json['current_observation']['precip_today_in']
+        if METRIC is 0:
+            precip_today = parsed_json['current_observation']['precip_today_in']
+        else:
+            precip_today = parsed_json['current_observation']['precip_today_metric']
+        print "Current precipitation in %s is: %s" % (location, precip_today)
 
-        print "Current precipitation in %s is: %s" % (location, precip_today_in)
-
-        if float(precip_today_in) > 0 :
+        if float(precip_today) > float(RAIN_THRESHOLD):
             print "Rain today, take the umbrella"
             assign_rain(True, BLINK)
 
@@ -141,8 +163,6 @@ try:
             print "No Rain today"
             assign_rain(False, BLINK)
 
-
-
 except KeyboardInterrupt:
     clear_led(0)
-    digitalWrite(rainled,0)
+    digitalWrite(rainled, 0)

--- a/Projects/rain_notifier/rain_notifier.py
+++ b/Projects/rain_notifier/rain_notifier.py
@@ -65,7 +65,6 @@ import json
 from grovepi import *
 import time
 import sys
-from my_rain_notifier import *
 
 
 def clear_led(status):
@@ -127,6 +126,8 @@ url = 'http://api.wunderground.com/api/' + api_key
 url = url + '/geolookup/conditions/q/' + zipcode + '.json'
 
 pinMode(rainled, "OUTPUT")
+if clearled > -1:
+    pinMode(clearled, "OUTPUT")
 
 
 if len(sys.argv) > 1 and sys.argv[1] == 'test':
@@ -139,8 +140,6 @@ if len(sys.argv) > 1 and sys.argv[1] == 'test':
         digitalWrite(rainled, 0)
     quit()
 
-if clearled > -1:
-    pinMode(clearled, "OUTPUT")
 
 try:
     while True:


### PR DESCRIPTION
"python rain_notifier test" will let user check hardware connections. (turn blue on port 8 on, and turn red on port 7 to blink)

METRIC set to 0 will work with inches of rain, set to anything else it will use millimeters.

RAIN_THRESHOLD lets user decide how much rain to tolerate before triggering a warning. 

make code PEP8 compliant
