### PR TITLE
Corrected clearInterval in sensor.js

### DIFF
--- a/Software/NodeJS/libs/sensors/base/sensor.js
+++ b/Software/NodeJS/libs/sensors/base/sensor.js
@@ -54,8 +54,8 @@ Sensor.prototype.watch = function(delay) {
   }, delay)
 }
 Sensor.prototype.stopWatch = function() {
-  if (typeof watchInterval != 'undefined' && typeof watchInterval.clearInterval == 'function')
-    watchInterval.clearInterval()
+  if (typeof watchInterval != 'undefined' && typeof clearInterval == 'function')
+    clearInterval(watchInterval)
 }
 
 module.exports = Sensor


### PR DESCRIPTION
watchInterval.clearInterval doesn't exist. The default clearInterval is used instead.