### PR TITLE
Changed Model enum to model names for consistency

### DIFF
--- a/Software/CSharp/GrovePi/Sensors/TemperatureAndHumiditySensor.cs
+++ b/Software/CSharp/GrovePi/Sensors/TemperatureAndHumiditySensor.cs
@@ -7,11 +7,19 @@ namespace GrovePi.Sensors
         double TemperatureInCelsius();
     }
 
+    /// <summary>
+    /// Specifies the model of sensor. 
+    /// DHT11 - blue one - comes with the GrovePi+ Starter Kit.
+    /// DHT22 - white one, aka DHT Pro or AM2302.
+    /// DHT21 - black one, aka AM2301.
+    /// </summary>
     public enum Model
     {
-        OnePointZero = 3975,
-        OnePointOne = 4250,
-        OnePointTwo = 4250
+        /* 
+        */
+        Dht11 = 3975,
+        Dht21 = 4250,
+        Dht22 = 4250
     }
 
     internal class TemperatureAndHumiditySensor : ITemperatureAndHumiditySensor


### PR DESCRIPTION
In every other platform software for Grove the DHT sensors are referred
to by name (DHT11, DHT21, DHT22), not 1.0, 1.1 and 1.2. I think this makes it easier to determine which sensor you are using and chose the right Model.