### PR TITLE
Airquality sensor interface added to device factory and Sensors listing

### DIFF
--- a/Software/CSharp/GrovePi/DeviceFactory.cs
+++ b/Software/CSharp/GrovePi/DeviceFactory.cs
@@ -21,6 +21,7 @@ namespace GrovePi
         ITemperatureAndHumiditySensor TemperatureAndHumiditySensor(Pin pin, Model model);
         IUltrasonicRangerSensor UltraSonicSensor(Pin pin);
         IAccelerometerSensor AccelerometerSensor(Pin pin);
+		IAirQualitySensor AirQualitySensor(Pin pin);
         IRealTimeClock RealTimeClock(Pin pin);
         ILedBar BuildLedBar(Pin pin);
         IFourDigitDisplay FourDigitDisplay(Pin pin);
@@ -69,6 +70,11 @@ namespace GrovePi
         public ITemperatureAndHumiditySensor TemperatureAndHumiditySensor(Pin pin, Model model)
         {
             return DoBuild(x => new TemperatureAndHumiditySensor(x, pin, model));
+        }
+		
+		 public IAirQualitySensor AirQualitySensor(Pin pin)
+        {
+            return DoBuild(x => new AirQualitySensor(x, pin));
         }
 
         public IUltrasonicRangerSensor UltraSonicSensor(Pin pin)

--- a/Software/CSharp/GrovePi/Sensors/AirQualitySensor.cs
+++ b/Software/CSharp/GrovePi/Sensors/AirQualitySensor.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+
+namespace GrovePi.Sensors
+{
+    public interface IAirQualitySensor
+    {
+        int AirQuality();
+    }
+    internal class AirQualitySensor : IAirQualitySensor
+    {
+        private readonly GrovePi _device;
+        private readonly Pin _pin;
+
+        internal AirQualitySensor(GrovePi device, Pin pin)
+        {
+            if (device == null) throw new ArgumentNullException(nameof(device));
+            device.PinMode(_pin, PinMode.Input);
+            _device = device;
+            _pin = pin;
+        }
+        public int AirQuality()
+        {
+            return _device.AnalogRead(_pin);
+        }
+    }
+}


### PR DESCRIPTION
Following changes have been introduced :

1> added Airquality Sensor Interface to the Device  factory - "GrovePi\Software\CSharp\GrovePi\DeviceFactory.cs".

2 > Implemented AirQuality Sensor to the list of Sensors - "GrovePi\Software\CSharp\GrovePi\Sensors\AirQualitySensor.cs"

Kindly check the changes, merge them and publish them through your nuget package so that we can test if AirQuality Sensor works fine.