### PR TITLE
Fix bug in pinmode usage

### DIFF
--- a/Software/CSharp/GrovePi/Sensors/Sensor.cs
+++ b/Software/CSharp/GrovePi/Sensors/Sensor.cs
@@ -10,9 +10,9 @@ namespace GrovePi.Sensors
         internal Sensor(IGrovePi device, Pin pin, PinMode pinMode)
         {
             if (device == null) throw new ArgumentNullException(nameof(device));
-            device.PinMode(Pin, pinMode);
             Device = device;
             Pin = pin;
+            device.PinMode(Pin, pinMode);
         }
 
         internal Sensor(IGrovePi device, Pin pin)


### PR DESCRIPTION
The device.PinMode was being set from internal members which had not been stored yet.  Would result in Relay module not working as expected.