### PR TITLE
Change pir_sensor to be equal to port number

### DIFF
--- a/Software/Python/grove_pir_motion_sensor.py
+++ b/Software/Python/grove_pir_motion_sensor.py
@@ -51,7 +51,7 @@ import grovepi
 
 # Connect the Grove PIR Motion Sensor to digital port D8
 # SIG,NC,VCC,GND
-pir_sensor = 7 
+pir_sensor = 8
 motion=0
 grovepi.pinMode(pir_sensor,"INPUT")
 


### PR DESCRIPTION
The documentation states that the device needs to be attached to D8. The change to the code now follows the documentation, as it first stated that it was connected to D7.