### PR TITLE
Update GroveGPS.py

### DIFF
--- a/Software/Python/GroveGPS.py
+++ b/Software/Python/GroveGPS.py
@@ -28,7 +28,7 @@ class GPS:
 	def read(self):	
 		while True:
 			# GPS.inp=ser.readline()
-			GPS.inp = readlineCR()
+			GPS.inp = readlineCR().strip()
 			if GPS.inp[:6] =='$GPGGA': # GGA data , packet 1, has all the data we need
 				break
 			time.sleep(0.1)


### PR DESCRIPTION
After the first successful read, there's an errant \n at the beginning of each string. The test on line 32 then fails. By using strip(), we sanitize the incoming string.