### PR TITLE
Add AnalogWrite method

### DIFF
--- a/Software/Go/grovepi/grovepi.go
+++ b/Software/Go/grovepi/grovepi.go
@@ -70,6 +70,16 @@ func (grovePi *GrovePi) AnalogRead(pin byte) (int, error) {
 	return ((v1 * 256) + v2), nil
 }
 
+func (grovePi *GrovePi) AnalogWrite(pin byte, val byte) error {
+	b := []byte{ANALOG_WRITE, pin, val, 0}
+	err := grovePi.i2cDevice.Write(1, b)
+	time.Sleep(100 * time.Millisecond)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (grovePi *GrovePi) DigitalRead(pin byte) (byte, error) {
 	b := []byte{DIGITAL_READ, pin, 0, 0}
 	err := grovePi.i2cDevice.Write(1, b)


### PR DESCRIPTION
Tested with the grovepi buzzer, enable sending analog write requests to
sensors with similar logic and parameters than DigitalWrite.