### PR TITLE
Cleaned code up, fixed issue with ReadDHT

### DIFF
--- a/Software/Go/grovepi/grovepi.go
+++ b/Software/Go/grovepi/grovepi.go
@@ -1,14 +1,15 @@
 package grovepi
 
 import (
-	"fmt"
-	"github.com/mrmorphic/hwio"
+	"encoding/binary"
+	"math"
 	"time"
-	"unsafe"
+
+	"github.com/mrmorphic/hwio"
 )
 
+// Pins
 const (
-	//Pins
 	A0 = 0
 	A1 = 1
 	A2 = 2
@@ -20,114 +21,123 @@ const (
 	D6 = 6
 	D7 = 7
 	D8 = 8
-
-	//Cmd format
-	DIGITAL_READ  = 1
-	DIGITAL_WRITE = 2
-	ANALOG_READ   = 3
-	ANALOG_WRITE  = 4
-	PIN_MODE      = 5
-	DHT_READ      = 40
 )
 
+// Commands format
+const (
+	CommandDigitalRead  = 1
+	CommandDigitalWrite = 2
+	CommandAnalogRead   = 3
+	CommandAnalogWrite  = 4
+	CommandPinMode      = 5
+	CommandDHTRead      = 40
+)
+
+// PinMode determines the pinmode for the GrovePi
+type PinMode byte
+
+// InputPin is the pinmode for input
+// OutputPin is the pinmode for output
+const (
+	InputPin  PinMode = 0
+	OutputPin         = 1
+)
+
+// GrovePi struct is used for handling the connection with board
 type GrovePi struct {
 	i2cmodule hwio.I2CModule
 	i2cDevice hwio.I2CDevice
 }
 
-func InitGrovePi(address int) *GrovePi {
+// Init initializes the GrovePi
+func Init(address int) (*GrovePi, error) {
 	grovePi := new(GrovePi)
 	m, err := hwio.GetModule("i2c")
 	if err != nil {
-		fmt.Printf("could not get i2c module: %s\n", err)
-		return nil
+		return nil, err
 	}
+
 	grovePi.i2cmodule = m.(hwio.I2CModule)
-	grovePi.i2cmodule.Enable()
+	err = grovePi.i2cmodule.Enable()
+	if err != nil {
+		return nil, err
+	}
 
 	grovePi.i2cDevice = grovePi.i2cmodule.GetDevice(address)
-	return grovePi
+	return grovePi, nil
 }
 
-func (grovePi *GrovePi) CloseDevice() {
+// Close closes the connection with the GrovePi
+func (grovePi *GrovePi) Close() {
 	grovePi.i2cmodule.Disable()
+	hwio.CloseAll()
 }
 
+// AnalogRead reads analogically to the GrovePi
 func (grovePi *GrovePi) AnalogRead(pin byte) (int, error) {
-	b := []byte{ANALOG_READ, pin, 0, 0}
+	b := []byte{CommandAnalogRead, pin, 0, 0}
 	err := grovePi.i2cDevice.Write(1, b)
 	if err != nil {
 		return 0, err
 	}
 	time.Sleep(100 * time.Millisecond)
+
 	grovePi.i2cDevice.ReadByte(1)
-	val, err2 := grovePi.i2cDevice.Read(1, 4)
-	if err2 != nil {
+	val, err := grovePi.i2cDevice.Read(1, 4)
+	if err != nil {
 		return 0, err
 	}
-	var v1 int = int(val[1])
-	var v2 int = int(val[2])
-	return ((v1 * 256) + v2), nil
+
+	return ((int(val[1]) << 8) | int(val[2])), nil
 }
 
+// DigitalRead reads digitally to the GrovePi
 func (grovePi *GrovePi) DigitalRead(pin byte) (byte, error) {
-	b := []byte{DIGITAL_READ, pin, 0, 0}
+	b := []byte{CommandDigitalRead, pin, 0, 0}
 	err := grovePi.i2cDevice.Write(1, b)
 	if err != nil {
 		return 0, err
 	}
 	time.Sleep(100 * time.Millisecond)
-	val, err2 := grovePi.i2cDevice.ReadByte(1)
-	if err2 != nil {
-		return 0, err2
-	}
-	return val, nil
+
+	return grovePi.i2cDevice.ReadByte(1)
 }
 
+// DigitalWrite writes digitally to the GrovePi
 func (grovePi *GrovePi) DigitalWrite(pin byte, val byte) error {
-	b := []byte{DIGITAL_WRITE, pin, val, 0}
+	b := []byte{CommandDigitalWrite, pin, val, 0}
 	err := grovePi.i2cDevice.Write(1, b)
 	time.Sleep(100 * time.Millisecond)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-func (grovePi *GrovePi) PinMode(pin byte, mode string) error {
-	var b []byte
-	if mode == "output" {
-		b = []byte{PIN_MODE, pin, 1, 0}
-	} else {
-		b = []byte{PIN_MODE, pin, 0, 0}
-	}
+// PinMode sets the GrovePi pinmode
+func (grovePi *GrovePi) PinMode(pin byte, mode PinMode) error {
+	b := []byte{CommandPinMode, pin, byte(mode), 0}
+
 	err := grovePi.i2cDevice.Write(1, b)
 	time.Sleep(100 * time.Millisecond)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
+// ReadDHT returns temperature and humidity from DHT sensor
 func (grovePi *GrovePi) ReadDHT(pin byte) (float32, float32, error) {
-	b := []byte{DHT_READ, pin, 1, 0}
+	b := []byte{CommandDHTRead, pin, 0, 0}
 	rawdata, err := grovePi.readDHTRawData(b)
 	if err != nil {
 		return 0, 0, err
 	}
-	temperatureData := rawdata[1:5]
 
-	tInt := int32(temperatureData[0]) | int32(temperatureData[1])<<8 | int32(temperatureData[2])<<16 | int32(temperatureData[3])<<24
-	t := (*(*float32)(unsafe.Pointer(&tInt)))
+	temperatureData := binary.LittleEndian.Uint32(rawdata[1:5])
+	t := math.Float32frombits(temperatureData)
 
-	humidityData := rawdata[5:9]
-	humInt := int32(humidityData[0]) | int32(humidityData[1])<<8 | int32(humidityData[2])<<16 | int32(humidityData[3])<<24
-	h := (*(*float32)(unsafe.Pointer(&humInt)))
+	humidityData := binary.LittleEndian.Uint32(rawdata[5:9])
+	h := math.Float32frombits(humidityData)
+
 	return t, h, nil
 }
 
 func (grovePi *GrovePi) readDHTRawData(cmd []byte) ([]byte, error) {
-
 	err := grovePi.i2cDevice.Write(1, cmd)
 	if err != nil {
 		return nil, err
@@ -135,9 +145,6 @@ func (grovePi *GrovePi) readDHTRawData(cmd []byte) ([]byte, error) {
 	time.Sleep(600 * time.Millisecond)
 	grovePi.i2cDevice.ReadByte(1)
 	time.Sleep(100 * time.Millisecond)
-	raw, err := grovePi.i2cDevice.Read(1, 9)
-	if err != nil {
-		return nil, err
-	}
-	return raw, nil
+
+	return grovePi.i2cDevice.Read(1, 9)
 }


### PR DESCRIPTION
Code was refactored by @adzeitor
Then I changed 

`b := []byte{CommandDHTRead, pin, 1, 0}`

to 

`b := []byte{CommandDHTRead, pin, 0, 0}`

as the first one returns weird values.
See http://forum.dexterindustries.com/t/how-to-convert-interpret-dht-sensor-to-human-readable-values-solved/2144/4