### PR TITLE
Fixed Node-crashing TypeError, typo, camelCase

### DIFF
--- a/Software/NodeJS/libs/sensors/digitalButton.js
+++ b/Software/NodeJS/libs/sensors/digitalButton.js
@@ -18,8 +18,8 @@ function DigitalButton(pin, longPressDelay) {
     this.on('change', function (res) {
         //user presses the button for the first time
         if (res == 1 && mode === buttonMode.UP) {
-            mode = buttonMode.DOWN
             pressedDateTime = new Date()
+            mode = buttonMode.DOWN
             return
         }
         //user continues to press the button

--- a/Software/NodeJS/libs/sensors/digitalButton.js
+++ b/Software/NodeJS/libs/sensors/digitalButton.js
@@ -5,19 +5,21 @@ const buttonMode = {
     DOWN: 1
 }
 
-let mode = buttonMode.UP //not pressed
+var mode = buttonMode.UP //not pressed
 
-let datetimePressed
+var pressedDateTime
+var currentDateTime
+var milliseconds
 
 //digital button, can throw singlepress and longpress events
-function DigitalButton(pin, longpressDelay) {
+function DigitalButton(pin, longPressDelay) {
     DigitalInput.apply(this, Array.prototype.slice.call(arguments))
-    this.longpressDelay = longpressDelay || 1100
+    this.longPressDelay = longPressDelay || 1100
     this.on('change', function (res) {
         //user presses the button for the first time
         if (res == 1 && mode === buttonMode.UP) {
             mode = buttonMode.DOWN
-            datetimePressed = new Date()
+            pressedDateTime = new Date()
             return
         }
         //user continues to press the button
@@ -25,10 +27,10 @@ function DigitalButton(pin, longpressDelay) {
             //do nothing
             return
         } else { //res == 0 so user has lifted her finger
-            let currentDateTime = new Date()
-            let miliseconds = currentDateTime.getTime() - datetimePressed.getTime()
-            //if less than longgpressDelay miliseconds
-            if (miliseconds <= this.longpressDelay) {
+            currentDateTime = new Date()
+            milliseconds = currentDateTime.getTime() - pressedDateTime.getTime()
+            //if less than longPressDelay milliseconds
+            if (milliseconds <= this.longPressDelay) {
                 this.emit('down', 'singlepress')
             } else {
                 this.emit('down', 'longpress')


### PR DESCRIPTION
# TypeError
When running this as a dependency with the GrovePi, Node consistently crashed with the following message:
`
/home/pi/.../node_modules/node-grovepi/sensors/digitalButton.js:27
               var milliseconds = currentDateTime.getTime() - pressedDateTime.getTime()
{ imagine an arrow pointing up at the dot "." in "pressedDateTime.getTime() }
TypeError: Cannot read property 'getTime of undefined
`
...whenever I tried pressing and holding the button to trigger my main program's event.
Defining the three variables involved at the top (instead of within the `if` statement) and changing all `let`s to `var`s fixed this problem.

# Typos
"miliseconds" (sic) -> "milliseconds"

# camelCase
"longpressDelay" -> "longPressDelay"
"datetimePressed" -> pressedDateTime  { matches format already used for "currentDateTime" }