### PR TITLE
Typo error in grove_light_sensor.py

### DIFF
--- a/Software/Python/grove_light_sensor.py
+++ b/Software/Python/grove_light_sensor.py
@@ -68,7 +68,7 @@ while True:
             # Send LOW to switch off LED
             grovepi.digitalWrite(led,0)
 
-        print("sensor_value = %d resistance =%.2f" %(sensor_value,  resistance))
+        print("sensor_value = %d resistance = %.2f" %(sensor_value,  resistance))
         time.sleep(.5)
 
     except IOError:


### PR DESCRIPTION
There should be a space before and after the equal.