### PR TITLE
hotfix - add option of installing a minimal version of the GrovePi

### DIFF
--- a/Script/README.md
+++ b/Script/README.md
@@ -20,11 +20,31 @@ The options that can be appended to this command are:
 
 * `--no-dependencies` - skip installing any dependencies for the GrovePi. It's supposed to be used on each consecutive update after the initial install has gone through.
 * `--no-update-aptget` - to skip using `sudo apt-get update` before installing dependencies. For this to be useful, `--no-dependencies` has to be not used.
+* `--no-grovepi-deb-packages` - skip installing debian packages with apt-get, but this doesn't mean it also skips installing whatever it's necessary to operate the GrovePi (avrdude, enabling I2C, etc). Lighter version of `--no-dependencies`.
 * `--bypass-rfrtools` - skips installing RFR_Tools completely.
 * `--bypass-python-rfrtools` - skips installing/updating the python package for  [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
+* `--bypass-gui-installation` - skips installing the GUI packages/dependencies from [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
 * `--user-local` - install the python package for the GrovePi in the home directory of the user. This doesn't require any special read/write permissions: the actual command used is (`python setup.py install --force --user`).
 * `--env-local` - install the python package for the GrovePi within the given environment without elevated privileges: the actual command used is (`python setup.py install --force`).
 * `--system-wide` - install the python package for the GrovePi within the sytem-wide environment with `sudo`: the actual command used is (`sudo python setup.py install --force`).
 
 Important to remember is that `--user-local`, `--env-local` and `--system-wide` options are all mutually-exclusive - they cannot be used together.
 As a last thing, different versions of it can be pulled by appending a corresponding branch name or tag.
+
+## Minimal Installation
+
+Now, if you only want the absolute minimum in order to get going with the GrovePi, you can run this commands in this order:
+```bash
+sudo apt-get update
+```
+```bash
+sudo apt-get install git libi2c-dev i2c-tools minicom \
+    python-setuptools python-pip python-smbus python-dev python-serial python-rpi.gpio python-numpy \
+    python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy
+    --no-install-recommends -y
+```
+```bash
+curl -kL dexterindustries.com/update_grovepi | sh -s -- --no-update-aptget --bypass-rfrtools
+```
+
+This will only get you installed the GrovePi dependencies and nothing else. You still can use options such as `--user-local` or `--env-local` if you are working with a different kind of environment. Keep in mind that `--system-wide` is selected by default.

--- a/Script/README.md
+++ b/Script/README.md
@@ -18,11 +18,11 @@ curl -kL dexterindustries.com/update_grovepi | bash -s -- --user-local --no-upda
 
 The options that can be appended to this command are:
 
-* `--no-dependencies` - skip installing any dependencies for the GrovePi. It's supposed to be used on each consecutive update after the initial install has gone through.
-* `--no-update-aptget` - to skip using `sudo apt-get update` before installing dependencies. For this to be useful, `--no-dependencies` has to be not used.
+* `--no-update-aptget` - to skip using `sudo apt-get update` before installing dependencies. For this to be useful, `--no-dependencies` has to be not used. Applies to RFR_Tools and the GrovePi.
 * `--bypass-rfrtools` - skips installing RFR_Tools completely.
-* `--bypass-python-rfrtools` - skips installing/updating the python package for  [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
-* `--bypass-gui-installation` - skips installing the GUI packages/dependencies from [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
+    * `--bypass-python-rfrtools` - skips installing/updating the python package for  [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
+    * `--bypass-gui-installation` - skips installing the GUI packages/dependencies from [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
+* `--no-dependencies` - skip installing any dependencies for the GrovePi. It's supposed to be used on each consecutive update after the initial install has gone through.
 * `--user-local` - install the python package for the GrovePi in the home directory of the user. This doesn't require any special read/write permissions: the actual command used is (`python setup.py install --force --user`).
 * `--env-local` - install the python package for the GrovePi within the given environment without elevated privileges: the actual command used is (`python setup.py install --force`).
 * `--system-wide` - install the python package for the GrovePi within the sytem-wide environment with `sudo`: the actual command used is (`sudo python setup.py install --force`).
@@ -32,9 +32,12 @@ As a last thing, different versions of it can be pulled by appending a correspon
 
 ## Minimal Installation
 
-Now, if you only want the absolute minimum in order to get going with the GrovePi, you can run this commands in this order:
+Now, if you only want the absolute minimum in order to get going with the GrovePi, you can run this commands in these orders:
 ```bash
-curl -kL dexterindustries.com/update_grovepi | sh -s -- --bypass-gui-installation
+sudo apt-get update && sudo apt-get install --no-install-recommends -y git
+```
+```bash
+curl -kL dexterindustries.com/update_grovepi | bash -s -- --bypass-gui-installation
 ```
 
 This will only get you installed the GrovePi dependencies and nothing else. You still can use options such as `--user-local` or `--env-local` if you are working with a different kind of environment. Keep in mind that `--system-wide` is selected by default.

--- a/Script/README.md
+++ b/Script/README.md
@@ -20,7 +20,6 @@ The options that can be appended to this command are:
 
 * `--no-dependencies` - skip installing any dependencies for the GrovePi. It's supposed to be used on each consecutive update after the initial install has gone through.
 * `--no-update-aptget` - to skip using `sudo apt-get update` before installing dependencies. For this to be useful, `--no-dependencies` has to be not used.
-* `--no-grovepi-deb-packages` - skip installing debian packages with apt-get, but this doesn't mean it also skips installing whatever it's necessary to operate the GrovePi (avrdude, enabling I2C, etc). Lighter version of `--no-dependencies`.
 * `--bypass-rfrtools` - skips installing RFR_Tools completely.
 * `--bypass-python-rfrtools` - skips installing/updating the python package for  [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
 * `--bypass-gui-installation` - skips installing the GUI packages/dependencies from [RFR_Tools](https://github.com/DexterInd/RFR_Tools).
@@ -35,16 +34,7 @@ As a last thing, different versions of it can be pulled by appending a correspon
 
 Now, if you only want the absolute minimum in order to get going with the GrovePi, you can run this commands in this order:
 ```bash
-sudo apt-get update
-```
-```bash
-sudo apt-get install git libi2c-dev i2c-tools minicom \
-    python-setuptools python-pip python-smbus python-dev python-serial python-rpi.gpio python-numpy \
-    python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy
-    --no-install-recommends -y
-```
-```bash
-curl -kL dexterindustries.com/update_grovepi | sh -s -- --no-update-aptget --bypass-rfrtools
+curl -kL dexterindustries.com/update_grovepi | sh -s -- --bypass-gui-installation
 ```
 
 This will only get you installed the GrovePi dependencies and nothing else. You still can use options such as `--user-local` or `--env-local` if you are working with a different kind of environment. Keep in mind that `--system-wide` is selected by default.

--- a/Script/install.sh
+++ b/Script/install.sh
@@ -14,23 +14,6 @@ display_welcome_msg() {
 	echo "Special thanks to Joe Sanford at Tufts University. This script was derived from his work. Thank you Joe!"
 }
 
-install_dependencies() {
-    # the sudo apt-get update is already
-    # done by the script_tools installer in
-    # update_grovepi.sh
-
-  	feedback "Installing dependencies for the GrovePi"
-    # in order for nodejs to be installed, the repo for it
-    # needs to be in; this is all done in script_tools while doing an apt-get update
-    sudo apt-get install nodejs -y
-
-  	sudo apt-get install git libi2c-dev i2c-tools arduino minicom -y
-    sudo apt-get install python-pip  python-smbus  python-dev  python-serial  python-rpi.gpio  python-scipy  python-numpy -y
-    sudo apt-get install python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-scipy python3-numpy -y
-
-    feedback "Dependencies for the GrovePi installed"
-}
-
 check_root_user() {
     if [[ $EUID -ne 0 ]]; then
         feedback "FAIL!  This script must be run as such: sudo ./install.sh"
@@ -100,6 +83,5 @@ install_avr() {
 
 display_welcome_msg
 check_root_user
-install_dependencies
 install_spi_i2c
 install_avr

--- a/Script/update_grovepi.sh
+++ b/Script/update_grovepi.sh
@@ -140,6 +140,7 @@ parse_cmdline_arguments() {
 ######## Cloning GrovePi & RFR_Tools  ##########
 ################################################
 
+# called in <<install_rfrtools_repo>>
 check_dependencies() {
   command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Error occurred with RFR_Tools installation." >&2; exit 1; }
   command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 2; }
@@ -248,13 +249,14 @@ remove_python_packages() {
 # called by <<install_python_pkgs_and_dependencies>>
 install_deb_dependencies() {
   feedback "Installing dependencies for the GrovePi"
+
   # in order for nodejs to be installed, the repo for it
   # needs to be in; this is all done in script_tools while doing an apt-get update
-  sudo apt-get install nodejs --no-install-recommends -y
+  sudo apt-get install nodejs --no-install-recommends -y \
+    git libi2c-dev i2c-tools \
+    python-setuptools python-pip python-smbus python-dev python-serial python-rpi.gpio python-numpy \
+    python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy
 
-  sudo apt-get install git libi2c-dev i2c-tools --no-install-recommends -y
-  sudo apt-get install python-setuptools python-pip python-smbus python-dev python-serial python-rpi.gpio python-numpy --no-install-recommends -y
-  sudo apt-get install python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy --no-install-recommends -y
   feedback "Dependencies for the GrovePi installed"
 }
 

--- a/Script/update_grovepi.sh
+++ b/Script/update_grovepi.sh
@@ -172,7 +172,8 @@ install_scriptools_and_rfrtools() {
 
   # if rfrtools is not bypassed then install it
   if [[ $install_rfrtools = "true" ]]; then
-    curl --silent -kL https://raw.githubusercontent.com/DexterInd/RFR_Tools/$selectedbranch/scripts/install_tools.sh > $PIHOME/.tmp_rfrtools.sh
+    # curl --silent -kL https://raw.githubusercontent.com/DexterInd/RFR_Tools/$selectedbranch/scripts/install_tools.sh > $PIHOME/.tmp_rfrtools.sh
+    curl --silent -kL https://raw.githubusercontent.com/RobertLucian/RFR_Tools/hotfix/add-gui-bypass/scripts/install_tools.sh > $PIHOME/.tmp_rfrtools.sh
     echo "Installing RFR_Tools. This might take a while.."
     bash $PIHOME/.tmp_rfrtools.sh ${rfrtools_options[@]} # > /dev/null
     ret_val=$?
@@ -195,7 +196,8 @@ clone_grovepi() {
   # it's simpler and more reliable (for now) to just delete the repo and clone a new one
   # otherwise, we'd have to deal with all the intricacies of git
   sudo rm -rf $GROVEPI_DIR
-  git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
+  # git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
+  git clone --quiet --depth=1 -b hotfix/add-minimal-install https://github.com/RobertLucian/GrovePi.git
   cd $GROVEPI_DIR
 }
 

--- a/Script/update_grovepi.sh
+++ b/Script/update_grovepi.sh
@@ -33,7 +33,6 @@ parse_cmdline_arguments() {
   # whether to install the dependencies or not (avrdude, apt-get, wiringpi, and so on)
   installdependencies=true
   updaterepo=true
-  installgrovepideb=true
   install_rfrtools=true
   install_pkg_rfrtools=true
   install_rfrtools_gui=true
@@ -56,9 +55,6 @@ parse_cmdline_arguments() {
         ;;
       --no-update-aptget)
         updaterepo=false
-        ;;
-      --no-grovepi-deb-packages)
-        installgrovepideb=false
         ;;
       --bypass-rfrtools)
         install_rfrtools=false
@@ -122,7 +118,6 @@ parse_cmdline_arguments() {
   echo "Updating GrovePi for $selectedbranch branch with the following options:"
   ([[ $installdependencies = "true" ]] && echo "  --no-dependencies=false") || echo "  --no-dependencies=true"
   ([[ $updaterepo = "true" ]] && echo "  --no-update-aptget=false") || echo "  --no-update-aptget=true"
-  ([[ $installgrovepideb == "true" ]] && echo "  --no-grovepi-deb-packages=false") || echo "  --no-grovepi-deb-packages=true"
   ([[ $install_rfrtools = "true" ]] && echo "  --bypass-rfrtools=false") || echo "  --bypass-rfrtools=true"
   ([[ $install_pkg_rfrtools = "true" ]] && echo "  --bypass-python-rfrtools=false") || echo "  --bypass-python-rfrtools=true"
   ([[ $install_rfrtools_gui = "true" ]] && echo "  --bypass-gui-installation=false") || echo "  --bypass-gui-installation=true"
@@ -131,7 +126,7 @@ parse_cmdline_arguments() {
   echo "  --system-wide=$systemwide"
 
   # in case the following packages are not installed and `--no-dependencies` option has been used
-  if [[ $installdependencies = "false" || $install_rfrtools = "false"  || $installgrovepideb = "false" ]]; then
+  if [[ $installdependencies = "false" || $install_rfrtools = "false" ]]; then
     command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Dependencies are set to be installed. Exiting." >&2; exit 1; }
     command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Dependencies are set to be installed. Exiting." >&2; exit 2; }
     command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Dependencies are set to be installed. Exiting." >&2; exit 3; }
@@ -259,11 +254,11 @@ install_deb_dependencies() {
   feedback "Installing dependencies for the GrovePi"
   # in order for nodejs to be installed, the repo for it
   # needs to be in; this is all done in script_tools while doing an apt-get update
-  sudo apt-get install nodejs -y
+  sudo apt-get install nodejs --no-install-recommends -y
 
-  sudo apt-get install git libi2c-dev i2c-tools minicom -y
-  sudo apt-get install python-setuptools python-pip python-smbus python-dev python-serial  python-rpi.gpio python-numpy -y
-  sudo apt-get install python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy -y
+  sudo apt-get install git libi2c-dev i2c-tools --no-install-recommends -y
+  sudo apt-get install python-setuptools python-pip python-smbus python-dev python-serial python-rpi.gpio python-numpy --no-install-recommends -y
+  sudo apt-get install python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy --no-install-recommends -y
   feedback "Dependencies for the GrovePi installed"
 }
 
@@ -272,11 +267,7 @@ install_python_pkgs_and_dependencies() {
   # installing dependencies if required
   if [[ $installdependencies = "true" ]]; then
     feedback "Installing GrovePi dependencies. This might take a while.."
-    if [[ $installgrovepideb = "true" ]]; then
-      install_deb_dependencies
-    else
-      feedback "Skipping the installation of deb packages for the GrovePi"
-    fi
+    install_deb_dependencies
     pushd $GROVEPI_DIR/Script > /dev/null
     sudo bash ./install.sh
     popd > /dev/null

--- a/Script/update_grovepi.sh
+++ b/Script/update_grovepi.sh
@@ -143,9 +143,11 @@ parse_cmdline_arguments() {
 check_dependencies() {
   command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Error occurred with RFR_Tools installation." >&2; exit 1; }
   command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 2; }
-  command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 3; }
-  command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 4; }
-  command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 5; }
+  command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 3; }
+  if [[ $usepython3exec = "true" ]]; then
+    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 4; }
+    command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 5; }
+  fi
 }
 
 # called way down below

--- a/Script/update_grovepi.sh
+++ b/Script/update_grovepi.sh
@@ -33,8 +33,10 @@ parse_cmdline_arguments() {
   # whether to install the dependencies or not (avrdude, apt-get, wiringpi, and so on)
   installdependencies=true
   updaterepo=true
+  installgrovepideb=true
   install_rfrtools=true
   install_pkg_rfrtools=true
+  install_rfrtools_gui=true
 
   # the following 3 options are mutually exclusive
   systemwide=true
@@ -55,11 +57,17 @@ parse_cmdline_arguments() {
       --no-update-aptget)
         updaterepo=false
         ;;
+      --no-grovepi-deb-packages)
+        installgrovepideb=false
+        ;;
       --bypass-rfrtools)
         install_rfrtools=false
         ;;
       --bypass-python-rfrtools)
         install_pkg_rfrtools=false
+        ;;
+      --bypass-gui-installation)
+        install_rfrtools_gui=false
         ;;
       --user-local)
         userlocal=true
@@ -114,19 +122,21 @@ parse_cmdline_arguments() {
   echo "Updating GrovePi for $selectedbranch branch with the following options:"
   ([[ $installdependencies = "true" ]] && echo "  --no-dependencies=false") || echo "  --no-dependencies=true"
   ([[ $updaterepo = "true" ]] && echo "  --no-update-aptget=false") || echo "  --no-update-aptget=true"
+  ([[ $installgrovepideb == "true" ]] && echo "  --no-grovepi-deb-packages=false") || echo "  --no-grovepi-deb-packages=true"
   ([[ $install_rfrtools = "true" ]] && echo "  --bypass-rfrtools=false") || echo "  --bypass-rfrtools=true"
   ([[ $install_pkg_rfrtools = "true" ]] && echo "  --bypass-python-rfrtools=false") || echo "  --bypass-python-rfrtools=true"
+  ([[ $install_rfrtools_gui = "true" ]] && echo "  --bypass-gui-installation=false") || echo "  --bypass-gui-installation=true"
   echo "  --user-local=$userlocal"
   echo "  --env-local=$envlocal"
   echo "  --system-wide=$systemwide"
 
   # in case the following packages are not installed and `--no-dependencies` option has been used
-  if [[ $installdependencies = "false" || $install_rfrtools = "false" ]]; then
-    command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Don't use --no-dependencies option. Exiting." >&2; exit 1; }
-    command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 2; }
-    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 3; }
-    command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 4; }
-    command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 5; }
+  if [[ $installdependencies = "false" || $install_rfrtools = "false"  || $installgrovepideb = "false" ]]; then
+    command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Dependencies are set to be installed. Exiting." >&2; exit 1; }
+    command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Dependencies are set to be installed. Exiting." >&2; exit 2; }
+    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Dependencies are set to be installed. Exiting." >&2; exit 3; }
+    command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Dependencies are set to be installed. Exiting." >&2; exit 4; }
+    command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Dependencies are set to be installed. Exiting." >&2; exit 5; }
   fi
 
   # create rest of list of arguments for rfrtools call
@@ -135,6 +145,7 @@ parse_cmdline_arguments() {
   [[ $updaterepo = "true" ]] && rfrtools_options+=("--update-aptget")
   [[ $installdependencies = "true" ]] && rfrtools_options+=("--install-deb-deps")
   [[ $install_pkg_rfrtools = "true" ]] && rfrtools_options+=("--install-python-package")
+  [[ $install_rfrtools_gui = "true" ]] && rfrtools_options+=("--install-gui")
 
   # create list of arguments for script_tools call
   declare -ga scriptools_options=("$selectedbranch")
@@ -150,6 +161,19 @@ parse_cmdline_arguments() {
 
 # called way down below
 install_scriptools_and_rfrtools() {
+  # update script_tools first
+  curl --silent -kL https://raw.githubusercontent.com/DexterInd/script_tools/$selectedbranch/install_script_tools.sh > $PIHOME/.tmp_script_tools.sh
+  echo "Installing script_tools. This might take a while.."
+  bash $PIHOME/.tmp_script_tools.sh $selectedbranch > /dev/null
+  ret_val=$?
+  rm $PIHOME/.tmp_script_tools.sh
+  if [[ $ret_val -ne 0 ]]; then
+    echo "script_tools failed installing with exit code $ret_val. Exiting."
+    exit 6
+  fi
+  # needs to be sourced from here when we call this as a standalone
+  source $DEXTERSCRIPT/functions_library.sh
+  feedback "Done installing script_tools"
 
   # if rfrtools is not bypassed then install it
   if [[ $install_rfrtools = "true" ]]; then
@@ -164,20 +188,6 @@ install_scriptools_and_rfrtools() {
     fi
     echo "Done installing RFR_Tool"
   fi
-
-  # update script_tools first
-  curl --silent -kL https://raw.githubusercontent.com/DexterInd/script_tools/$selectedbranch/install_script_tools.sh > $PIHOME/.tmp_script_tools.sh
-  echo "Installing script_tools. This might take a while.."
-  bash $PIHOME/.tmp_script_tools.sh $selectedbranch > /dev/null
-  ret_val=$?
-  rm $PIHOME/.tmp_script_tools.sh
-  if [[ $ret_val -ne 0 ]]; then
-    echo "script_tools failed installing with exit code $ret_val. Exiting."
-    exit 6
-  fi
-  # needs to be sourced from here when we call this as a standalone
-  source $DEXTERSCRIPT/functions_library.sh
-  feedback "Done installing script_tools"
 }
 
 # called way down bellow
@@ -245,11 +255,28 @@ remove_python_packages() {
   done < $PIHOME/.pypaths
 }
 
+install_deb_dependencies() {
+  feedback "Installing dependencies for the GrovePi"
+  # in order for nodejs to be installed, the repo for it
+  # needs to be in; this is all done in script_tools while doing an apt-get update
+  sudo apt-get install nodejs -y
+
+  sudo apt-get install git libi2c-dev i2c-tools minicom -y
+  sudo apt-get install python-setuptools python-pip python-smbus python-dev python-serial  python-rpi.gpio python-numpy -y
+  sudo apt-get install python3-setuptools python3-pip python3-smbus python3-dev python3-serial python3-rpi.gpio python3-numpy -y
+  feedback "Dependencies for the GrovePi installed"
+}
+
 # called way down bellow
 install_python_pkgs_and_dependencies() {
   # installing dependencies if required
   if [[ $installdependencies = "true" ]]; then
     feedback "Installing GrovePi dependencies. This might take a while.."
+    if [[ $installgrovepideb = "true" ]]; then
+      install_deb_dependencies
+    else
+      feedback "Skipping the installation of deb packages for the GrovePi"
+    fi
     pushd $GROVEPI_DIR/Script > /dev/null
     sudo bash ./install.sh
     popd > /dev/null

--- a/Script/update_grovepi.sh
+++ b/Script/update_grovepi.sh
@@ -148,6 +148,11 @@ check_dependencies() {
     command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 4; }
     command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Error occurred with RFR_Tools installation." >&2; exit 5; }
   fi
+
+  if [[ ! -f $DEXTERSCRIPT/functions_library.sh ]]; then
+    echo "script_tools didn\'t get installed. Enable the installation of dependencies with RFR_Tools.'"
+    exit 7
+  fi
 }
 
 # called way down below


### PR DESCRIPTION
Add another option called `--no-grovepi-deb-packages` to skip installing debian packages. But with this option, the user is forced to install the dependencies (not all of them though) before launching the install script.

Theoretically, the smallest number of needed packages are just these: `python-pip python3-pip` and `git` but in the README a couple more are added.

Also, an option to drop the GUI installation from [RFR_Tools](https://github.com/DexterInd/RFR_Tools) has been added.

In order for this to work, https://github.com/DexterInd/RFR_Tools/pull/13 is required.

Solves #424 