### PR TITLE
Replaced deprecated dustSensorRead()

### DIFF
--- a/Software/Python/grove_dust_sensor.py
+++ b/Software/Python/grove_dust_sensor.py
@@ -51,7 +51,7 @@ print("Reading from the dust sensor")
 grovepi.dust_sensor_en()
 while True:
     try:
-		[new_val,lowpulseoccupancy] = grovepi.dustSensorRead()
+		[new_val,lowpulseoccupancy] = grovepi.dust_sensor_read()
 		if new_val:
 			print(lowpulseoccupancy)
 		time.sleep(5) 


### PR DESCRIPTION
The dustSensorRead() method in grovepi.py is deprecated, thus the example script will not execute. This example works again if the name is changed to 'dust_sensor_read()'.