### PR TITLE
add info about compatibility with Raspberry PI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The old guide on getting started with the GrovePi can be found [here](http://www
 
 ## Support
 
+### Raspberry Pi Compatibility
+The GrovePi is compatible with the Raspberry Pi models A, A+, B, B+, 2, and 3.
+
 ### Scratch Support
 Once you've done the above command, you can install Scratch support if you want it. This step is optional.
 ```


### PR DESCRIPTION
https://github.com/DexterInd/GrovePi/commit/a29c92146a801b15dc254f1d328141de49598290#diff-04c6e90faac2675aa89e2176d2eec7d8L14

is there any reasoning behind this change? why info about compatible Raspberry PI devices was removed from Readme? For me it's a very important information as I spend quite a bit of time trying to figure out why it's not working with RPI 4. Would be great to see it again in README. Would be great to add info about upcoming release date for RPI4 or at least the info that work is in progress at the moment.