### PR TITLE
 fix analogRead not returning a value

### DIFF
--- a/Software/Python/grovepi.py
+++ b/Software/Python/grovepi.py
@@ -238,7 +238,7 @@ def read_i2c_block(no_bytes = max_recv_size):
 
 def read_identified_i2c_block(read_command_id, no_bytes):
 	data = [-1]
-	while data[0] != read_command_id[0]:
+	while len(data) <= 1:
 		data = read_i2c_block(no_bytes + 1)
 
 	return data[1:]


### PR DESCRIPTION
Hello.
I have been trying to get light using Grove LightSensor. I have run the following program, but at `grovepi.analogRead` the program gets stuck like an infinite loop and does not return any value.
I have done the firmware updates and such that have been mentioned in other Issues, but the situation has not improved.

```python
import grovepi
from time import sleep

while True:
    light = grovepi.analogRead(0)
    print(light)
    if light >= 100:
        print("light!")
    sleep(1)
```

I have modified `grovepi.py` as per this pull request. The program seems to be working fine. But to be honest, I'm not sure what I fixed. I'm not sure about this pull request.

```diff
def read_identified_i2c_block(read_command_id, no_bytes):
        data = [-1]
-       while data[0] != read_command_id[0]:
+       while len(data) <= 1:
                data = read_i2c_block(no_bytes + 1)

        return data[1:]
```

## Related issues
- https://github.com/DexterInd/GrovePi/issues/442
- https://github.com/DexterInd/GrovePi/issues/451

Thanks.