### PR TITLE
Removed Deprecated NodeJS Buffertools Module

### DIFF
--- a/Software/NodeJS/libs/grovepi.js
+++ b/Software/NodeJS/libs/grovepi.js
@@ -4,7 +4,6 @@ var async       = require('async')
 var log         = require('npmlog')
 var sleep       = require('sleep')
 var fs          = require('fs')
-var bufferTools = require('buffertools').extend()
 var commands    = require('./commands')
 
 var I2CCMD    = 1

--- a/Software/NodeJS/libs/package.json
+++ b/Software/NodeJS/libs/package.json
@@ -5,7 +5,6 @@
     "keywords": ["grovepi", "robot", "gpio", "i2c"],
     "dependencies": {
         "async": "1.*",
-        "buffertools": "2.1.*",
         "i2c-bus": "1.*",
         "npmlog": "2.*",
         "sleep": "3.*",


### PR DESCRIPTION
The Buffertools module is no longer needed, and it may cause issues with newer versions of NodeJS. 